### PR TITLE
Fix sorts across nullable relationships

### DIFF
--- a/sqlalchemy_filters/filters.py
+++ b/sqlalchemy_filters/filters.py
@@ -19,8 +19,13 @@ from six import string_types
 from sqlalchemy import and_, or_, not_, func
 
 from .exceptions import BadFilterFormat
-from .models import Field, auto_join, get_model_from_spec, get_relationship_models, \
-    should_outer_join_relationship
+from .models import (
+    Field,
+    auto_join,
+    get_model_from_spec,
+    get_relationship_models,
+    should_filter_outer_join_relationship,
+)
 
 BooleanFunction = namedtuple(
     'BooleanFunction', ('key', 'sqlalchemy_fn', 'only_one_arg')
@@ -98,7 +103,7 @@ class Filter(object):
         operator = self.filter_spec['op'] if 'op' in self.filter_spec else None
 
         models = get_relationship_models(model, field)
-        return (list(), models) if should_outer_join_relationship(operator) else (models, list())
+        return (list(), models) if should_filter_outer_join_relationship(operator) else (models, list())
 
     def format_for_sqlalchemy(self, query, default_model):
         filter_spec = self.filter_spec

--- a/sqlalchemy_filters/models.py
+++ b/sqlalchemy_filters/models.py
@@ -56,8 +56,16 @@ def get_relationship_models(model, field):
     return list()
 
 
-def should_outer_join_relationship(operator):
+def should_filter_outer_join_relationship(operator):
     return operator == 'is_null'
+
+
+def should_sort_outer_join_relationship(models):
+    return any(
+        column.nullable
+        for rel_model in models
+        for column in rel_model.prop.local_columns
+    )
 
 
 def find_nested_relationship_model(mapper, field):

--- a/sqlalchemy_filters/models.py
+++ b/sqlalchemy_filters/models.py
@@ -61,11 +61,12 @@ def should_filter_outer_join_relationship(operator):
 
 
 def should_sort_outer_join_relationship(models):
-    return any(
-        column.nullable
-        for rel_model in models
-        for column in rel_model.prop.local_columns
-    )
+    for rel_model in models:
+        if rel_model.prop.direction == symbol('ONETOMANY'):
+            return True
+        elif any(column.nullable for column in rel_model.prop.local_columns):
+            return True
+    return False
 
 
 def find_nested_relationship_model(mapper, field):

--- a/sqlalchemy_filters/sorting.py
+++ b/sqlalchemy_filters/sorting.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from .exceptions import BadSortFormat
-from .models import Field, auto_join, get_model_from_spec, get_default_model, get_relationship_models, \
-    should_outer_join_relationship
+from .models import (
+    Field,
+    auto_join,
+    get_model_from_spec,
+    get_relationship_models,
+    should_sort_outer_join_relationship,
+)
 
 SORT_ASCENDING = 'asc'
 SORT_DESCENDING = 'desc'
@@ -35,11 +40,9 @@ class Sort(object):
 
     def get_named_models(self, model):
         field = self.sort_spec['field']
-        operator = self.sort_spec['op'] if 'op' in self.sort_spec else None
-
         models = get_relationship_models(model, field)
 
-        return (list(), models) if should_outer_join_relationship(operator) else (models, list())
+        return (list(), models) if should_sort_outer_join_relationship(models) else (models, list())
 
     def format_for_sqlalchemy(self, query, default_model):
         sort_spec = self.sort_spec


### PR DESCRIPTION
Sort specs including certain fields by default cause an INNER join, resulting in a lower result count than expected. This is the case at least in the following scenarios:
- nullable foreign keys: sorting refers to a field on a nullable foreign relation. This excludes NULL values from the result.
- one-to-many relationships: sorting refers to a field on a one-to-many relation. These are never guaranteed to exist; if missing, lines with no matching relation are excluded.

This surfaces when using dotted fields directly in a sort spec, but also caculated fields (e.g. sorting by related entity counts).

This PR evaluates the relationships included in the sort spec on if they include nullable fields or one-to-many relations, and changes the join type to OUTER where appropriate. This might not be exhaustive yet, but covers some common cases.