### PR TITLE
CC-3316 Check that entity is set

### DIFF
--- a/sqlalchemy_filters/models.py
+++ b/sqlalchemy_filters/models.py
@@ -115,7 +115,7 @@ def get_query_models(query):
     :returns:
         A dictionary with all the models included in the query.
     """
-    models = [col_desc['entity'] for col_desc in query.column_descriptions]
+    models = [col_desc['entity'] for col_desc in query.column_descriptions if col_desc['entity']]
     models.extend(mapper.class_ for mapper in query._join_entities)
 
     # account also query.select_from entities


### PR DESCRIPTION
Fixes https://github.com/Harborn-digital/caru-containers-lambda/pull/3189/checks?check_run_id=15945714708

```
E           File "/github/home/.cache/pypoetry/virtualenvs/caru-containers-lambda-cDQ_M3T8-py3.8/lib/python3.8/site-packages/sqlalchemy_filters/models.py", line 161, in get_model_from_spec
E             models = get_query_models(query)
E           File "/github/home/.cache/pypoetry/virtualenvs/caru-containers-lambda-cDQ_M3T8-py3.8/lib/python3.8/site-packages/sqlalchemy_filters/models.py", line 134, in get_query_models
E             return {model.__name__: model for model in models}
E           File "/github/home/.cache/pypoetry/virtualenvs/caru-containers-lambda-cDQ_M3T8-py3.8/lib/python3.8/site-packages/sqlalchemy_filters/models.py", line 134, in <dictcomp>
E             return {model.__name__: model for model in models}
E         AttributeError: 'NoneType' object has no attribute '__name__'
```